### PR TITLE
fix: fully flatten allOf; handle oneOf/anyOf more correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21.0
 
 require (
 	github.com/getkin/kin-openapi v0.128.0
+	github.com/go-test/deep v1.0.8
 	github.com/speakeasy-api/openapi-overlay v0.9.0
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/text v0.20.0

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/go-test/deep"
 	"golang.org/x/tools/imports"
 
 	"github.com/oapi-codegen/oapi-codegen/v2/pkg/util"
@@ -719,8 +720,16 @@ func GenerateTypes(t *template.Template, types []TypeDefinition) (string, error)
 				continue
 			}
 			// We want to create an error when we try to define the same type twice.
-			return "", fmt.Errorf("duplicate typename '%s' detected, can't auto-rename, "+
-				"please use x-go-name to specify your own name for one of them", typ.TypeName)
+			diff := deep.Equal(prevType.Schema.OAPISchema, typ.Schema.OAPISchema)
+			return "", fmt.Errorf(
+				"duplicate typename '%s', can't auto-rename, "+
+					"please use x-go-name to specify your own name for one of them"+
+					"\n\tpath1:\n\t\t%s\n\tpath2:\n\t\t%s\n\tdiff:\n\t\t%s",
+				typ.TypeName,
+				prevType.JsonName,
+				typ.JsonName,
+				strings.Join(diff, "\n\t\t"),
+			)
 		}
 
 		m[typ.TypeName] = typ

--- a/pkg/codegen/merge_schemas.go
+++ b/pkg/codegen/merge_schemas.go
@@ -125,7 +125,9 @@ func mergeOpenapiSchemas(s1, s2 openapi3.Schema) (openapi3.Schema, error) {
 
 	// NOTE: this must happen _after_ AllOf merging above or OneOfs can be lost, for example:
 	//          SchemaFoo: {allOf: [{allOf: [{oneOf: [A, B]}], SchemaBar]}
-	//       the resulting schema will only include SchemaBar
+	//       the resulting schema will only include SchemaBar if OneOf merging is done before
+	//       AllOf recursion - this is because we won't have any deeply nested OneOfs flattened
+	//       into s1/s2 yet at that point
 	// TODO: this does not accurately merge OneOf/AnyOf, for example if an AllOf contains 2
 	//       OneOf schema children, the result should require one from each set, but this will
 	//       require only one from the combined set

--- a/pkg/codegen/merge_schemas.go
+++ b/pkg/codegen/merge_schemas.go
@@ -37,7 +37,7 @@ func mergeSchemas(allOf []*openapi3.SchemaRef, path []string) (Schema, error) {
 		if err != nil {
 			return Schema{}, err
 		}
-		schema, err = mergeOpenapiSchemas(schema, oneOfSchema, true)
+		schema, err = mergeOpenapiSchemas(schema, oneOfSchema)
 		if err != nil {
 			return Schema{}, fmt.Errorf("error merging schemas for AllOf: %w", err)
 		}
@@ -74,7 +74,7 @@ func mergeAllOf(allOf []*openapi3.SchemaRef) (openapi3.Schema, error) {
 	var schema openapi3.Schema
 	for _, schemaRef := range allOf {
 		var err error
-		schema, err = mergeOpenapiSchemas(schema, *schemaRef.Value, true)
+		schema, err = mergeOpenapiSchemas(schema, *schemaRef.Value)
 		if err != nil {
 			return openapi3.Schema{}, fmt.Errorf("error merging schemas for AllOf: %w", err)
 		}
@@ -84,7 +84,7 @@ func mergeAllOf(allOf []*openapi3.SchemaRef) (openapi3.Schema, error) {
 
 // mergeOpenapiSchemas merges two openAPI schemas and returns the schema
 // all of whose fields are composed.
-func mergeOpenapiSchemas(s1, s2 openapi3.Schema, allOf bool) (openapi3.Schema, error) {
+func mergeOpenapiSchemas(s1, s2 openapi3.Schema) (openapi3.Schema, error) {
 	var result openapi3.Schema
 
 	result.Extensions = make(map[string]interface{})
@@ -96,10 +96,13 @@ func mergeOpenapiSchemas(s1, s2 openapi3.Schema, allOf bool) (openapi3.Schema, e
 		result.Extensions[k] = v
 	}
 
-	result.OneOf = append(s1.OneOf, s2.OneOf...)
-
 	// We are going to make AllOf transitive, so that merging an AllOf that
 	// contains AllOf's will result in a flat object.
+	// TODO: this does not account for other schema fields at the same level as
+	//       an AllOf - they will be lost, see also where MergeSchemas is used
+	//       in GenerateGoSchema (all fields from the parent are disregarded
+	//       and instead only the schema containing the merged AllOfs is
+	//       returned)
 	var err error
 	if s1.AllOf != nil {
 		var merged openapi3.Schema
@@ -119,6 +122,15 @@ func mergeOpenapiSchemas(s1, s2 openapi3.Schema, allOf bool) (openapi3.Schema, e
 	}
 
 	result.AllOf = append(s1.AllOf, s2.AllOf...)
+
+	// NOTE: this must happen _after_ AllOf merging above or OneOfs can be lost, for example:
+	//          SchemaFoo: {allOf: [{allOf: [oneOf: [A, B]}, SchemaBar]}
+	//       the resulting schema will only include SchemaBar
+	// TODO: this does not accurately merge OneOf/AnyOf, for example if an AllOf contains 2
+	//       OneOf schema children, the result should require one from each set, but this will
+	//       require only one from the combined set
+	result.OneOf = append(s1.OneOf, s2.OneOf...)
+	result.AnyOf = append(s1.AnyOf, s2.AnyOf...)
 
 	if s1.Type.Slice() != nil && s2.Type.Slice() != nil && !equalTypes(s1.Type, s2.Type) {
 		return openapi3.Schema{}, fmt.Errorf("can not merge incompatible types: %v, %v", s1.Type.Slice(), s2.Type.Slice())
@@ -220,11 +232,6 @@ func mergeOpenapiSchemas(s1, s2 openapi3.Schema, allOf bool) (openapi3.Schema, e
 				result.WithAnyAdditionalProperties()
 			}
 		}
-	}
-
-	// Allow discriminators for allOf merges, but disallow for one/anyOfs.
-	if !allOf && (s1.Discriminator != nil || s2.Discriminator != nil) {
-		return openapi3.Schema{}, errors.New("merging two schemas with discriminators is not supported")
 	}
 
 	return result, nil

--- a/pkg/codegen/merge_schemas.go
+++ b/pkg/codegen/merge_schemas.go
@@ -124,7 +124,7 @@ func mergeOpenapiSchemas(s1, s2 openapi3.Schema) (openapi3.Schema, error) {
 	result.AllOf = append(s1.AllOf, s2.AllOf...)
 
 	// NOTE: this must happen _after_ AllOf merging above or OneOfs can be lost, for example:
-	//          SchemaFoo: {allOf: [{allOf: [oneOf: [A, B]}, SchemaBar]}
+	//          SchemaFoo: {allOf: [{allOf: [{oneOf: [A, B]}], SchemaBar]}
 	//       the resulting schema will only include SchemaBar
 	// TODO: this does not accurately merge OneOf/AnyOf, for example if an AllOf contains 2
 	//       OneOf schema children, the result should require one from each set, but this will

--- a/pkg/codegen/merge_schemas_test.go
+++ b/pkg/codegen/merge_schemas_test.go
@@ -252,6 +252,35 @@ func TestAllOf(t *testing.T) {
 			]`,
 			nil,
 		),
+		// other test cases
+		makeTestCase(
+			"should preserve nested onOf",
+			`[
+				{
+					"allOf": [
+						{
+							"allOf": [
+								{
+									"oneOf": [
+										{"properties": { "a_foo_one_of_0": { "type": "string" } }},
+										{"properties": { "a_foo_one_of_1": { "type": "string" } }}
+									]
+								}
+							]
+						}, 
+						{ "properties": { "a_foo": { "type": "string" } } }
+					]
+				}
+			]`,
+			`{
+				"a_foo": { "type": "string" }
+			}`,
+			`[
+				{ "properties": { "a_foo_one_of_0": { "type": "string" } }},
+				{ "properties": { "a_foo_one_of_1": { "type": "string" } }}
+			]`,
+			nil,
+		),
 	}
 
 	runSuite(t, suite)

--- a/pkg/codegen/merge_schemas_test.go
+++ b/pkg/codegen/merge_schemas_test.go
@@ -1,0 +1,372 @@
+package codegen
+
+import (
+	"encoding/json"
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/go-test/deep"
+)
+
+func TestAllOf(t *testing.T) {
+	suite := []testCase{
+		// just properties
+		makeTestCase(
+			"when 1 level deep, it merges schemas",
+			`[
+				{ "properties": { "a_foo": { "type": "string" } } },
+				{ "properties": { "b_foo": { "type": "string" } } }
+			]`,
+			`{ "a_foo": { "type": "string" }, "b_foo": { "type": "string" } }`,
+			"",
+			nil,
+		),
+		makeTestCase(
+			"when 1 level deep with 1 schema, it returns single schema",
+			`[
+				{ "properties": { "a_foo": { "type": "string" } } }
+			]`,
+			`{ "a_foo": { "type": "string" } }`,
+			"",
+			nil,
+		),
+		makeTestCase(
+			"when 3 levels deep, it merges schemas",
+			`[
+				{
+					"allOf": [
+						{
+							"allOf": [
+								{"properties": { "a0_foo": { "type": "string" } }},
+								{"properties": { "a1_foo": { "type": "string" } }}
+							]
+						}
+					]
+				},
+				{
+					"allOf": [
+						{
+							"allOf": [
+								{"properties": { "b0_foo": { "type": "string" } }},
+								{"properties": { "b1_foo": { "type": "string" } }}
+							]
+						}
+					]
+				}
+			]`,
+			`{
+				"a0_foo": { "type": "string" },
+				"a1_foo": { "type": "string" },
+				"b0_foo": { "type": "string" },
+				"b1_foo": { "type": "string" }
+			}`,
+			"",
+			nil,
+		),
+		makeTestCase(
+			"when 3 levels deep with single schema, it flattens to single schema",
+			`[
+				{
+					"allOf": [
+						{
+							"allOf": [
+								{"properties": { "a0_foo": { "type": "string" } }},
+								{"properties": { "a1_foo": { "type": "string" } }}
+							]
+						}
+					]
+				}
+			]`,
+			`{
+				"a0_foo": { "type": "string" },
+				"a1_foo": { "type": "string" }
+			}`,
+			"",
+			nil,
+		),
+		// include single oneOf
+		makeTestCase(
+			"when 1 level deep with oneOf, it merges schemas",
+			`[
+				{
+					"properties": { "a_foo": { "type": "string" } },
+					"oneOf": [
+						{ "properties": { "a_foo_one_of_0": { "type": "string" } }},
+						{ "properties": { "a_foo_one_of_1": { "type": "string" } }}
+					]
+				},
+				{ "properties": { "b_foo": { "type": "string" } } }
+			]`,
+			`{ "a_foo": { "type": "string" }, "b_foo": { "type": "string" } }`,
+			`[
+				{ "properties": { "a_foo_one_of_0": { "type": "string" } }},
+				{ "properties": { "a_foo_one_of_1": { "type": "string" } }}
+			]`,
+			nil,
+		),
+		makeTestCase(
+			"when 3 levels deep with oneOf at leaf, it merges schemas",
+			`[
+				{
+					"allOf": [
+						{
+							"allOf": [
+								{
+									"properties": { "a0_foo": { "type": "string" } },
+									"oneOf": [
+										{ "properties": { "a_foo_one_of_0": { "type": "string" } }},
+										{ "properties": { "a_foo_one_of_1": { "type": "string" } }}
+									]
+								},
+								{ "properties": { "a1_foo": { "type": "string" } } }
+							]
+						}
+					]
+				},
+				{
+					"allOf": [
+						{
+							"allOf": [
+								{"properties": { "b0_foo": { "type": "string" } }},
+								{"properties": { "b1_foo": { "type": "string" } }}
+							]
+						}
+					]
+				}
+			]`,
+			`{
+				"a0_foo": { "type": "string" },
+				"a1_foo": { "type": "string" },
+				"b0_foo": { "type": "string" },
+				"b1_foo": { "type": "string" }
+			}`,
+			`[
+				{ "properties": { "a_foo_one_of_0": { "type": "string" } }},
+				{ "properties": { "a_foo_one_of_1": { "type": "string" } }}
+			]`,
+			nil,
+		),
+		makeTestCase(
+			"when 3 levels deep with oneOf in the middle, it merges schemas",
+			`[
+				{
+					"allOf": [
+						{
+							"oneOf": [
+								{ "properties": { "a_foo_one_of_0": { "type": "string" } }},
+								{ "properties": { "a_foo_one_of_1": { "type": "string" } }}
+							]
+						},
+						{
+							"allOf": [
+								{"properties": { "a0_foo": { "type": "string" } }},
+								{"properties": { "a1_foo": { "type": "string" } }}
+							]
+						}
+					]
+				},
+				{
+					"allOf": [
+						{
+							"allOf": [
+								{"properties": { "b0_foo": { "type": "string" } }},
+								{"properties": { "b1_foo": { "type": "string" } }}
+							]
+						}
+					]
+				}
+			]`,
+			`{
+				"a0_foo": { "type": "string" },
+				"a1_foo": { "type": "string" },
+				"b0_foo": { "type": "string" },
+				"b1_foo": { "type": "string" }
+			}`,
+			`[
+				{ "properties": { "a_foo_one_of_0": { "type": "string" } }},
+				{ "properties": { "a_foo_one_of_1": { "type": "string" } }}
+			]`,
+			nil,
+		),
+		makeTestCase(
+			"with multi-level oneOf, it merges schemas",
+			`[
+				{
+					"allOf": [
+						{
+							"allOf": [
+								{"properties": { "a0_foo": { "type": "string" } }},
+								{"properties": { "a1_foo": { "type": "string" } }}
+							]
+						},
+						{
+							"oneOf": [
+								{
+									"allOf": [
+										{"properties": { "a_foo_one_of_a_0": { "type": "string" } }},
+										{"properties": { "a_foo_one_of_a_1": { "type": "string" } }}
+									]
+								},
+								{
+									"allOf": [
+										{"properties": { "a_foo_one_of_b_0": { "type": "string" } }},
+										{"properties": { "a_foo_one_of_b_1": { "type": "string" } }}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					"allOf": [
+						{
+							"allOf": [
+								{"properties": { "b0_foo": { "type": "string" } }},
+								{"properties": { "b1_foo": { "type": "string" } }}
+							]
+						}
+					]
+				}
+			]`,
+			`{
+				"a0_foo": { "type": "string" },
+				"a1_foo": { "type": "string" },
+				"b0_foo": { "type": "string" },
+				"b1_foo": { "type": "string" }
+			}`,
+			`[
+				{
+					"properties": {
+						"a_foo_one_of_a_0": { "type": "string" },
+						"a_foo_one_of_a_1": { "type": "string" }
+					}
+				},
+				{
+					"properties": {
+						"a_foo_one_of_b_0": { "type": "string" },
+						"a_foo_one_of_b_1": { "type": "string" }
+					}
+				}
+			]`,
+			nil,
+		),
+	}
+
+	runSuite(t, suite)
+}
+
+func runSuite(t *testing.T, suite []testCase) {
+	for _, test := range suite {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := MergeSchemas(test.inputAllOf, make([]string, 0))
+
+			if diff := deep.Equal(err, test.expectedError); diff != nil {
+				var errString = "Error validation failed. diff:"
+				for _, diffItem := range diff {
+					errString += "\n\t" + diffItem
+				}
+				t.Fatal(errString)
+				return
+			}
+			if err != nil {
+				return
+			}
+
+			// result.OAPISchema is an intermediate schema (it's currently the schema after recursing
+			// AllOf, but but before recursing Properties/Enums/everything else that needs recursing),
+			// so we need to pull merged props off the "codegen" version
+			// NOTE: normally result.OAPISchema would be the "original" schema when calling
+			//       `GenerateGoSchema`, but we are testing `MergeSchemas` directly here
+			err = validateProperties(&test.expectedProperties, &result)
+			if err != nil {
+				t.Fatal(err)
+				return
+			}
+
+			// similar to above, the OneOfs are after the first pass or merging, so we extract
+			// the properties for comparison
+			// TODO: current tests only care about properties, but we should also test other fields
+			if len(result.UnionElements) != len(test.expectedOneOf) {
+				t.Fatalf("Expected %d oneOfs, got %d", len(test.expectedOneOf), len(result.UnionElements))
+				return
+			}
+			for i, oneOf := range result.UnionElements {
+				typeIdx := slices.IndexFunc(result.AdditionalTypes, func(t TypeDefinition) bool { return t.TypeName == oneOf.GoType })
+				if typeIdx == -1 {
+					t.Fatalf("Expected oneOf %d to have type %s, but it was not found", i, oneOf.GoType)
+					return
+				}
+				oneOfType := result.AdditionalTypes[typeIdx]
+				expectedOneOf := test.expectedOneOf[i]
+				// see notes on validateProperties above
+				err = validateProperties(&expectedOneOf.Value.Properties, &oneOfType.Schema)
+				if err != nil {
+					t.Fatal(err)
+					return
+				}
+			}
+		})
+	}
+}
+
+func validateProperties(expectedProperties *openapi3.Schemas, result *Schema) error {
+	props := openapi3.Schemas{}
+	for _, prop := range result.Properties {
+		props[prop.JsonFieldName] = openapi3.NewSchemaRef("", prop.Schema.OAPISchema)
+	}
+	if diff := deep.Equal(props, *expectedProperties); diff != nil {
+		var errString = "Properties validation failed. diff:"
+		for _, diffItem := range diff {
+			errString += "\n\t" + diffItem
+		}
+		return errors.New(errString)
+	}
+
+	return nil
+}
+
+type testCase struct {
+	name               string
+	inputAllOf         openapi3.SchemaRefs
+	expectedProperties openapi3.Schemas
+	expectedOneOf      openapi3.SchemaRefs
+	expectedError      error
+}
+
+func makeTestCase(
+	name string,
+	inputAllOfSchema string,
+	expectedPropertiesSchema string,
+	expectedOneOfSchema string,
+	expectedError error,
+) testCase {
+	inputAllOf := openapi3.SchemaRefs{}
+	if err := json.Unmarshal([]byte(inputAllOfSchema), &inputAllOf); err != nil {
+		panic(err)
+	}
+
+	var expectedProperties openapi3.Schemas
+	if len(expectedPropertiesSchema) > 0 {
+		if err := json.Unmarshal([]byte(expectedPropertiesSchema), &expectedProperties); err != nil {
+			panic(err)
+		}
+	}
+
+	var expectedOneOf openapi3.SchemaRefs = nil
+	if len(expectedOneOfSchema) > 0 {
+		expectedOneOf = openapi3.SchemaRefs{}
+		if err := json.Unmarshal([]byte(expectedOneOfSchema), &expectedOneOf); err != nil {
+			panic(err)
+		}
+	}
+
+	return testCase{
+		name:               name,
+		inputAllOf:         inputAllOf,
+		expectedProperties: expectedProperties,
+		expectedOneOf:      expectedOneOf,
+		expectedError:      expectedError,
+	}
+}

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -84,7 +84,7 @@ type Property struct {
 	JsonFieldName string
 	Schema        Schema
 	Required      bool
-	Nullable      bool
+	Nullable      *bool
 	ReadOnly      bool
 	WriteOnly     bool
 	NeedsFormTag  bool
@@ -115,11 +115,12 @@ func (p Property) GoFieldName() string {
 
 func (p Property) GoTypeDef() string {
 	typeDef := p.Schema.TypeDecl()
-	if globalState.options.OutputOptions.NullableType && p.Nullable {
+	nullable := p.Nullable != nil && *p.Nullable
+	if globalState.options.OutputOptions.NullableType && nullable {
 		return "nullable.Nullable[" + typeDef + "]"
 	}
 	if !p.Schema.SkipOptionalPointer &&
-		(!p.Required || p.Nullable ||
+		(!p.Required || nullable ||
 			(p.ReadOnly && (!p.Required || !globalState.options.Compatibility.DisableRequiredReadOnlyAsPointer)) ||
 			p.WriteOnly) {
 
@@ -714,9 +715,10 @@ func GenFieldsFromProperties(props []Property) []string {
 		shouldOmitEmpty := (!p.Required || p.ReadOnly || p.WriteOnly) &&
 			(!p.Required || !p.ReadOnly || !globalState.options.Compatibility.DisableRequiredReadOnlyAsPointer)
 
-		omitEmpty := !p.Nullable && shouldOmitEmpty
+		nullable := p.Nullable != nil && *p.Nullable
+		omitEmpty := !nullable && shouldOmitEmpty
 
-		if p.Nullable && globalState.options.OutputOptions.NullableType {
+		if nullable && globalState.options.OutputOptions.NullableType {
 			omitEmpty = shouldOmitEmpty
 		}
 
@@ -780,7 +782,8 @@ func additionalPropertiesType(schema Schema) string {
 	if schema.AdditionalPropertiesType.RefType != "" {
 		addPropsType = schema.AdditionalPropertiesType.RefType
 	}
-	if schema.AdditionalPropertiesType.OAPISchema != nil && schema.AdditionalPropertiesType.OAPISchema.Nullable {
+	oapiSchema := schema.AdditionalPropertiesType.OAPISchema
+	if oapiSchema != nil && oapiSchema.Nullable != nil && *oapiSchema.Nullable {
 		addPropsType = "*" + addPropsType
 	}
 	return addPropsType

--- a/pkg/codegen/schema_test.go
+++ b/pkg/codegen/schema_test.go
@@ -206,7 +206,7 @@ func TestProperty_GoTypeDef(t *testing.T) {
 			p := Property{
 				Schema:    tt.fields.Schema,
 				Required:  tt.fields.Required,
-				Nullable:  tt.fields.Nullable,
+				Nullable:  &tt.fields.Nullable,
 				ReadOnly:  tt.fields.ReadOnly,
 				WriteOnly: tt.fields.WriteOnly,
 			}
@@ -446,7 +446,7 @@ func TestProperty_GoTypeDef_nullable(t *testing.T) {
 			p := Property{
 				Schema:    tt.fields.Schema,
 				Required:  tt.fields.Required,
-				Nullable:  tt.fields.Nullable,
+				Nullable:  &tt.fields.Nullable,
 				ReadOnly:  tt.fields.ReadOnly,
 				WriteOnly: tt.fields.WriteOnly,
 			}


### PR DESCRIPTION
the main purpose of this PR is to fix the situation where `oneOf` gets lost in deeply nested `allOf` schemas, for example:
```json
{
  "allOf": [
    {
      "allOf": [
        {
          "oneOf": [
            { "properties": { "a_foo_one_of_0": { "type": "string" } } },
            { "properties": { "a_foo_one_of_1": { "type": "string" } } }
          ]
        }
      ]
    },
    { "properties": { "a_foo": { "type": "string" } } }
  ]
}
```
see added comments in `merge_schemas.go` for explanation

other fixes/improvements:
* includes `anyOf` as well as `oneOf` during schema merge
* improves duplicate typename log message (includes path and detailed diff)
* removes unused parameter in `mergeOpenapiSchemas`